### PR TITLE
feat(admin): add cancel button to provider edit form

### DIFF
--- a/client/src/components/AdminProviderForm.tsx
+++ b/client/src/components/AdminProviderForm.tsx
@@ -341,6 +341,17 @@ export function AdminProviderForm({ editProvider, onEditComplete, onSearchChange
         )}
 
         <div className="flex flex-col sm:flex-row gap-3">
+          {editProvider && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onEditComplete}
+              className="w-full sm:w-auto"
+              data-testid="button-cancel-edit"
+            >
+              Cancel
+            </Button>
+          )}
           <Button
             type="button"
             variant="outline"


### PR DESCRIPTION
Add a cancel button that appears when editing a provider, allowing users to exit edit mode. The button is conditionally rendered based on the editProvider prop and triggers the onEditComplete callback.

Refs: #12