### PR TITLE
fix(admin): invalidate tokens query on provider deletion

### DIFF
--- a/client/src/components/AdminProviderList.tsx
+++ b/client/src/components/AdminProviderList.tsx
@@ -64,6 +64,7 @@ export function AdminProviderList({ }: AdminProviderListProps) {
       await api.deleteProvider(id);
       queryClient.invalidateQueries({ queryKey: ["/api/admin/providers"] });
       queryClient.invalidateQueries({ queryKey: ["/api/providers/public"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/tokens"] });
       toast({
         title: "Provider Deleted",
         description: "Provider has been deleted successfully",


### PR DESCRIPTION
Add queryClient invalidation for admin tokens when a provider is deleted to ensure the token list refreshes and reflects any tokens that may have been affected by the provider removal.