### PR TITLE
feat(tokens): add ability to regenerate API keys

### DIFF
--- a/client/src/components/AdminUserTokenList.tsx
+++ b/client/src/components/AdminUserTokenList.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { Trash2, Copy, Edit } from "lucide-react";
+import { Trash2, Copy, Edit, RefreshCw } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
@@ -158,6 +158,29 @@ export function AdminUserTokenList({ }: AdminUserTokenListProps) {
       title: "Token Copied",
       description: "Token has been copied to clipboard",
     });
+  };
+
+  const regenerateToken = async (id: string, name: string) => {
+    if (!confirm(`Are you sure you want to regenerate the API key for "${name}"? The old key will stop working immediately.`)) {
+      return;
+    }
+
+    try {
+      const newToken = await api.regenerateUserToken(id);
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/tokens"] });
+      toast({
+        title: "Token Regenerated",
+        description: "A new API key has been generated successfully",
+      });
+      // Automatically copy the new token to clipboard
+      navigator.clipboard.writeText(newToken.token);
+    } catch (error: any) {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to regenerate token",
+        variant: "destructive",
+      });
+    }
   };
 
   const deleteToken = async (id: string) => {
@@ -366,6 +389,14 @@ export function AdminUserTokenList({ }: AdminUserTokenListProps) {
                         onClick={() => copyToken(token.token)}
                         data-testid={`button-copy-${token.id}`}>
                         <Copy className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => regenerateToken(token.id, token.name)}
+                        data-testid={`button-regenerate-${token.id}`}
+                        title="Regenerate API key">
+                        <RefreshCw className="h-3 w-3" />
                       </Button>
                     </div>
                   </div>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -337,4 +337,15 @@ export const api = {
       if (!res.ok) throw new Error("Failed to delete user token");
       return res.json();
     }),
+
+  regenerateUserToken: (tokenId: string) =>
+    fetch(`/api/admin/tokens/${tokenId}/regenerate`, {
+      method: "POST",
+    }).then(async (res) => {
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || "Failed to regenerate user token");
+      }
+      return res.json();
+    }),
 };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -981,6 +981,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.json({ success });
   });
 
+  app.post("/api/admin/tokens/:id/regenerate", adminAuth, async (req: Request, res: Response) => {
+    try {
+      const token = await storage.regenerateUserToken(req.params.id);
+      if (!token) {
+        return res.status(404).json({ error: "Token not found" });
+      }
+      res.json(token);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  });
+
   app.get("/api/debug/ip", (req: Request, res: Response) => {
     res.json({
       cfConnectingIP: req.get('cf-connecting-ip'),

--- a/server/sqlite-storage.ts
+++ b/server/sqlite-storage.ts
@@ -758,6 +758,21 @@ export class SQLiteStorage implements IStorage {
     }
   }
 
+  async regenerateUserToken(id: string): Promise<UserToken | undefined> {
+    try {
+      const newToken = "sk_" + randomUUID().replace(/-/g, "");
+      const stmt = this.db.prepare('UPDATE user_tokens SET token = ? WHERE id = ?');
+      const result = stmt.run(newToken, id);
+
+      if (result.changes === 0) return undefined;
+
+      return this.getUserTokenById(id);
+    } catch (error) {
+      console.error('Error regenerating user token:', error);
+      throw error;
+    }
+  }
+
   // Sub-key specific methods
   async getSubKeys(parentTokenId: string): Promise<UserToken[]> {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -67,6 +67,7 @@ export interface IStorage {
   createUserToken(userToken: InsertUserToken): Promise<UserToken>;
   updateUserToken(id: string, userToken: Partial<InsertUserToken>): Promise<UserToken | undefined>;
   deleteUserToken(id: string): Promise<boolean>;
+  regenerateUserToken(id: string): Promise<UserToken | undefined>;
 
   // Sub-key methods
   getSubKeys(parentTokenId: string): Promise<UserToken[]>;


### PR DESCRIPTION
Implement token regeneration functionality allowing admins to reroll user API keys while preserving the token record. The regenerated token is automatically copied to the clipboard for convenience.

Changes include:
- Added regenerateUserToken method to storage layer that updates the token value while keeping the same ID
- Added POST /api/admin/tokens/:id/regenerate endpoint with admin authentication
- Added client-side regenerateToken function with confirmation dialog and toast notifications
- Added RefreshCw icon button in token list UI for token regeneration action
- New token value is automatically copied to clipboard after successful regeneration