### PR TITLE
feat(storage): LGPD/GDPR right to erasure — user data anonymization & deletion

### DIFF
--- a/client/src/components/AdminUserList.tsx
+++ b/client/src/components/AdminUserList.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Ban, ShieldCheck, Wifi, WifiOff, Shield, Briefcase, UserCog, Search } from "lucide-react";
+import { Ban, ShieldCheck, Wifi, WifiOff, Shield, Briefcase, UserCog, Search, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useMemo } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -54,6 +54,7 @@ export function AdminUserList() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [banDialogOpen, setBanDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [rolesDialogOpen, setRolesDialogOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState<DiscordUser | null>(null);
   const [banReason, setBanReason] = useState("");
@@ -106,6 +107,17 @@ export function AdminUserList() {
     setBanDialogOpen(true);
   };
 
+  const handleDeleteClick = (user: DiscordUser) => {
+    setSelectedUser(user);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (selectedUser) {
+      deleteMutation.mutate(selectedUser.id);
+    }
+  };
+
   const handleBanConfirm = () => {
     if (selectedUser) {
       banMutation.mutate({ userId: selectedUser.id, reason: banReason || undefined });
@@ -125,6 +137,26 @@ export function AdminUserList() {
       toast({
         title: "Error",
         description: error.message || "Failed to unban user",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (userId: string) => api.deleteUser(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "users"] });
+      setDeleteDialogOpen(false);
+      setSelectedUser(null);
+      toast({
+        title: "User Deleted",
+        description: "User data has been anonymized per LGPD/GDPR right to erasure.",
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to delete user",
         variant: "destructive",
       });
     },
@@ -353,6 +385,17 @@ export function AdminUserList() {
                       Ban
                     </Button>
                   )}
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleDeleteClick(user)}
+                    disabled={deleteMutation.isPending || (user.roles || ["user"]).includes("admin")}
+                    title={user.roles?.includes("admin") ? "Cannot delete admin accounts" : "Delete user and anonymize logs (LGPD/GDPR)"}
+                    className="align-middle"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                  </Button>
                 </TableCell>
               </TableRow>
             ))
@@ -401,6 +444,48 @@ export function AdminUserList() {
               disabled={banMutation.isPending}
             >
               {banMutation.isPending ? "Banning..." : "Ban User"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete User</DialogTitle>
+            <DialogDescription>
+              You are about to permanently delete {selectedUser?.globalName || selectedUser?.username}.
+              This action cannot be undone. The user's request log entries will have their IP addresses
+              irreversibly hashed (LGPD/GDPR right to erasure), and the user link will be severed.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <p className="text-sm text-muted-foreground">
+              All of the following will be anonymized or removed:
+            </p>
+            <ul className="list-disc list-inside text-sm text-muted-foreground mt-2 space-y-1">
+              <li>User account deleted from discord_users</li>
+              <li>User API keys revoked</li>
+              <li>IP addresses replaced with one-way irreversible hashes in request logs</li>
+              <li>User reference removed from all logs</li>
+            </ul>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDeleteDialogOpen(false);
+                setSelectedUser(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteConfirm}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting..." : "Delete User"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -259,6 +259,17 @@ export const api = {
       return res.json();
     }),
 
+  deleteUser: (userId: string) =>
+    fetch(`/api/admin/users/${userId}`, {
+      method: "DELETE",
+    }).then(async (res) => {
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || "Failed to delete user");
+      }
+      return res.json();
+    }),
+
   updateUserRoles: (userId: string, roles: string[]) =>
     fetch(`/api/admin/users/${userId}/roles`, {
       method: "POST",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1551,6 +1551,33 @@ export async function registerRoutes(app: Express): Promise<Server> {
     },
   );
 
+  // Delete user / scrub personal data (LGPD/GDPR right to erasure)
+  app.delete(
+    "/api/admin/users/:id",
+    await requireRole("admin"),
+    async (req: Request, res: Response) => {
+      try {
+        const userId = req.params.id;
+        const user = await storage.getDiscordUser(userId);
+        if (!user) {
+          return res.status(404).json({ error: "User not found" });
+        }
+        // Prevent deleting admin accounts
+        const userRoles = user.roles || ["user"];
+        if (userRoles.includes("admin")) {
+          return res.status(403).json({ error: "Cannot delete admin accounts" });
+        }
+        // Anonymize IP addresses in request_logs, then delete the discord_users row
+        await storage.scrubUserData(userId);
+        // Actually delete the user row (cascade deletes user_api_keys, usage_records, etc.)
+        await storage.deleteDiscordUser(userId);
+        res.json({ success: true });
+      } catch (error: any) {
+        res.status(500).json({ error: error.message });
+      }
+    },
+  );
+
   // Update user roles - Super Admin can manage all roles, Discord Admins can only manage provider role
   app.post(
     "/api/admin/users/:id/roles",

--- a/server/sqlite-storage.ts
+++ b/server/sqlite-storage.ts
@@ -100,6 +100,7 @@ export class SQLiteStorage implements IStorage {
       this.ensureRequestLogsTable();
       this.ensureUserApiKeysTable();
       this.ensureUsageRecordsDiscordUserId();
+      this.ensureUsageRecordsNullableUserId();
       this.ensureUsageRecordsProviderTimestampIndex();
     } catch (error) {
       console.error("Error initializing database:", error);
@@ -205,6 +206,55 @@ export class SQLiteStorage implements IStorage {
         "CREATE INDEX idx_usage_records_provider_timestamp ON usage_records(provider_id, timestamp)",
       );
     }
+  }
+
+  // Migrate usage_records.discord_user_id from NOT NULL to nullable (allows ON DELETE SET NULL to work)
+  private ensureUsageRecordsNullableUserId(): void {
+    const tableCheck = this.db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='usage_records'",
+      )
+      .get();
+    if (!tableCheck) {
+      return;
+    }
+    const columns = this.db
+      .prepare("PRAGMA table_info(usage_records)")
+      .all() as { name: string; notnull: number }[];
+    const discordCol = columns.find((col) => col.name === "discord_user_id");
+    if (!discordCol || discordCol.notnull === 0) {
+      return; // Already nullable
+    }
+    this.db.exec(
+      "CREATE TABLE IF NOT EXISTS usage_records_new AS SELECT * FROM usage_records",
+    );
+    this.db.exec("DROP TABLE usage_records");
+    this.db.exec(`
+      CREATE TABLE usage_records (
+        id TEXT PRIMARY KEY,
+        discord_user_id TEXT,
+        model_id TEXT,
+        provider_id TEXT,
+        tokens INTEGER DEFAULT 0,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        timestamp INTEGER NOT NULL,
+        cost REAL NOT NULL DEFAULT 1.0,
+        FOREIGN KEY (discord_user_id) REFERENCES discord_users(id) ON DELETE SET NULL,
+        FOREIGN KEY (model_id) REFERENCES models(id) ON DELETE SET NULL,
+        FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE SET NULL
+      )
+    `);
+    this.db.exec(
+      "INSERT INTO usage_records SELECT id, discord_user_id, model_id, provider_id, tokens, input_tokens, output_tokens, timestamp, cost FROM usage_records_new",
+    );
+    this.db.exec("DROP TABLE usage_records_new");
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_usage_records_discord_user_id ON usage_records(discord_user_id)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_usage_records_timestamp ON usage_records(timestamp)",
+    );
   }
 
   private ensureDiscordUserIpColumns(): void {
@@ -333,7 +383,7 @@ export class SQLiteStorage implements IStorage {
       this.db.exec(`
         CREATE TABLE IF NOT EXISTS usage_records (
           id TEXT PRIMARY KEY,
-          discord_user_id TEXT NOT NULL,
+          discord_user_id TEXT,
           model_id TEXT,
           provider_id TEXT,
           tokens INTEGER DEFAULT 0,
@@ -1687,6 +1737,48 @@ export class SQLiteStorage implements IStorage {
       return row ? this.rowToUserApiKey(row) : undefined;
     } catch (error) {
       console.error("Error updating user API key rate limits:", error);
+      throw error;
+    }
+  }
+
+  // User deletion / IP anonymization
+  // LGPD/GDPR right to erasure: replaces IP addresses with one-way irreversible hashes
+  // and severs the user link in request_logs. The salt is never stored, making the hash
+  // irreversible even internally. All updates run in a single transaction for SQLite performance.
+  async scrubUserData(userId: string): Promise<void> {
+    const scrubUser = this.db.transaction(() => {
+      // Deduplicate IPs first: hash each unique IP once, then bulk-update
+      const rows = this.db
+        .prepare(
+          "SELECT DISTINCT ip FROM request_logs WHERE discord_user_id = ?",
+        )
+        .all(userId) as { ip: string }[];
+
+      const ipMap = new Map<string, string>();
+      for (const { ip } of rows) {
+        const salt = crypto.getRandomValues(new Uint8Array(32));
+        const hasher = new Bun.CryptoHasher("sha256");
+        hasher.update(Buffer.from(salt).toString("hex") + ip);
+        ipMap.set(ip, hasher.digest("hex"));
+      }
+
+      const update = this.db.prepare(
+        "UPDATE request_logs SET ip = ?, discord_user_id = NULL WHERE discord_user_id = ? AND ip = ?",
+      );
+      for (const [original, hashed] of ipMap) {
+        update.run(hashed, userId, original);
+      }
+    });
+
+    scrubUser();
+  }
+
+  async deleteDiscordUser(userId: string): Promise<void> {
+    try {
+      const stmt = this.db.prepare("DELETE FROM discord_users WHERE id = ?");
+      stmt.run(userId);
+    } catch (error) {
+      console.error("Error deleting Discord user:", error);
       throw error;
     }
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -89,6 +89,10 @@ export interface IStorage {
   createUserApiKey(userId: string): Promise<UserApiKey>;
   rotateUserApiKey(id: string): Promise<UserApiKey | undefined>;
   updateUserApiKeyRateLimits(id: string, maxRPD: number, maxRPM: number): Promise<UserApiKey | undefined>;
+
+  // User deletion / IP anonymization
+  scrubUserData(userId: string): Promise<void>;
+  deleteDiscordUser(userId: string): Promise<void>;
 }
 
 import { SQLiteStorage } from './sqlite-storage';


### PR DESCRIPTION
## Summary

This PR implements **GDPR/LGPD right to erasure** functionality, allowing the deletion of user accounts with full anonymization of personally identifiable information (PII) in request logs. Specifically, IP addresses are irreversibly hashed using a one-way cryptographic hash with a per-IP randomly generated salt that is **never stored**, making it impossible to reverse-engineer the original IP address from the stored data — even internally.

---

## What This PR Does

### For End Users (Non-Technical)
When a user requests deletion of their account under GDPR (EU) or LGPD (Brazil) data protection laws, the platform:

1. **Deletes the user account** — removes all stored Discord user data
2. **Revokes API keys** — prevents further API access
3. **Anonymizes IP addresses in request logs** — replaces each IP with a unique, irreversible hash
4. **Sevvers the user link** — removes the Discord user ID from log entries

This means the user's identity is completely severed from their request history. The logs still exist (for platform analytics and troubleshooting), but there is no way to connect them to a specific person or IP address.

### For Technical Reviewers
The anonymization works as follows:

- For each distinct IP address found in a user's request logs, a **cryptographically random 32-byte salt** is generated using `crypto.getRandomValues`
- The salt is concatenated with the IP address and fed into a **SHA-256 cryptographic hash** (`Bun.CryptoHasher`)
- The resulting hash is stored back into the request log **in place of** the original IP
- The salt is **immediately discarded** — it is never written to disk, stored in memory long-term, or transmitted anywhere

Because SHA-256 is a **one-way function** and the salt is never stored, there exists no possible method to recover the original IP address from the hashed value. Even platform administrators with full database access cannot reverse this operation.

### Why This Is Irreversible

```
Original IP:  192.168.1.100
       ↓
Salt generated: 0x3f8a9c2e... (random, 32 bytes)
       ↓
Concatenated: "0x3f8a9c2e...192.168.1.100"
       ↓
SHA-256 Hash: "a7b3c9d8e1f2..."
       ↓
Stored: "a7b3c9d8e1f2..."
       ↓
Salt discarded — cannot be recovered
```

To reverse the process, you would need to know the original salt value. Since it was generated randomly for each IP and **never persisted**, reversal is mathematically impossible.

---

## Changes

| File | Change |
|------|--------|
| `server/storage.ts` | Added interface declarations for `scrubUserData()` and `deleteDiscordUser()` |
| `server/sqlite-storage.ts` | Full implementation of both methods with transactional integrity; added migration to make `discord_user_id` nullable in `usage_records` (enables `ON DELETE SET NULL` cascade) |
| `server/routes.ts` | Added `DELETE /api/admin/users/:id` endpoint with admin role guard and explicit prevention of deleting admin accounts |
| `client/src/lib/api.ts` | Added `deleteUser()` API client method |
| `client/src/components/AdminUserList.tsx` | Added Delete button with confirmation dialog and disabled state for admin users |

---

## Legal Compliance

| Regulation | Article | Requirement | Implemented |
|-----------|---------|-------------|-------------|
| **GDPR** (EU) | Article 17 | Right to erasure ("right to be forgotten") | ✅ |
| **LGPD** (Brazil) | Article 18 | Right to deletion of personal data | ✅ |

### Why logs are retained (not deleted)
Request logs are preserved because they are essential for:
- Platform security monitoring
- Abuse detection and prevention
- Operational troubleshooting
- Billing and usage analytics

These legitimate interests of the platform are balanced against the user's right to erasure by **anonymizing** rather than **deleting** the logs. Anonymized logs serve the platform's legitimate interests while eliminating any risk to the user's privacy.

---

## Test Plan

- [x] Verify `DELETE /api/admin/users/:id` returns 403 for admin users (both API and UI)
- [x] Verify `DELETE /api/admin/users/:id` anonymizes IP addresses in `request_logs` before user deletion
- [x] Verify original IP cannot be recovered from hashed value in database
- [x] Verify `usage_records` correctly sets `discord_user_id = NULL` via `ON DELETE SET NULL` cascade
- [x] Verify non-admin users can be deleted successfully end-to-end